### PR TITLE
Update ag format and set grepprg per call

### DIFF
--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -7,7 +7,7 @@ function! PrepGrep()
     let g:grepprg="git --no-pager grep -n"
   else
     if executable("ag")
-      let g:grepprg="ag --nogroup --column --hidden"
+      let g:grepprg="ag --vimgrep --column --hidden"
     else
       let g:grepprg="grep -rnH "
     endif

--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -1,5 +1,5 @@
 " Grep utility
-if !exists("g:grepprg")
+function! PrepGrep()
   let output = system("git rev-parse --is-inside-work-tree")
   let is_git_repo = v:shell_error == 0
 
@@ -12,7 +12,7 @@ if !exists("g:grepprg")
       let g:grepprg="grep -rnH "
     endif
   endif
-endif
+endfunction
 
 function! FormatForProgram(program)
   if match(a:program, '^a(g|ck)') != -1
@@ -23,6 +23,7 @@ function! FormatForProgram(program)
 endfunction
 
 function! s:Grep(cmd, args)
+  call PrepGrep()
   call FormatForProgram(g:grepprg)
 
   if exists(":Dispatch")

--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -9,7 +9,7 @@ function! PrepGrep()
     if executable("ag")
       let g:grepprg="ag --vimgrep --column --hidden"
     else
-      let g:grepprg="grep -rnH "
+      let g:grepprg="grep -rnH"
     endif
   endif
 endfunction


### PR DESCRIPTION
This PR fixes a few small issues pertaining for search result formatting. In addition, it sets grepprg on each call to :Grep rather than just once. The benefit is to handle cases where I am editing files across multiple projects/contexts and have each one respect the grep selection logic accordingly.

For example, if I open a git tracked file in one tab, and then a file in /tmp in another page, it will use `git grep` in the first and `ag` in the second.

I understand if the latter is a little too aggressive for your plugin, it fits my workflow nicely but it may not be what you are after. If so let me know and I can drop that part from my PR