### PR TITLE
Ignore STDERR from command output

### DIFF
--- a/plugin/grep.vim
+++ b/plugin/grep.vim
@@ -22,8 +22,8 @@ function! s:Grep(cmd, args)
   call PrepGrep()
   let args = a:args
   if match(a:cmd, '^l\?grep') != -1
-    " Pass a dir to grep
-    let args = args . ' .'
+    " Pass a dir to grep, and ignore any STDERR
+    let args = args . ' . 2>/dev/null'
   endif
 
   if exists(":Dispatch")


### PR DESCRIPTION
STDERR doesn't seem to provide useful output and leads to parsing problems and lines that don't matter -- for example, when grep finds a binary file, it prints to STDERR, but we don't care about that information